### PR TITLE
Remove S3 connection close.

### DIFF
--- a/operators/salesforce_to_s3_operator.py
+++ b/operators/salesforce_to_s3_operator.py
@@ -223,8 +223,6 @@ class SalesforceToS3Operator(BaseOperator):
                 replace=True
             )
 
-            dest_s3.connection.close()
-
             tmp.close()
 
         logging.info("Query finished!")


### PR DESCRIPTION
Since S3Hook doesn't have a connection attribute, this will throw an exception.

Link to the Issue:
#5 


Solution:
remove `dest_s3.connection.close()`
which was not accessible in airflow 1.9
