### PR TITLE
(feat): added date selection parameters in salesforce to S3 operator

### DIFF
--- a/operators/salesforce_to_s3_operator.py
+++ b/operators/salesforce_to_s3_operator.py
@@ -6,7 +6,7 @@ from airflow.utils.decorators import apply_defaults
 from airflow.models import BaseOperator
 from airflow.hooks.S3_hook import S3Hook
 
-from airflow.contrib.hooks.salesforce_hook import SalesforceHook
+from airflow.providers.salesforce.hooks.salesforce import SalesforceHook
 
 
 class SalesforceBulkQueryToS3Operator(BaseOperator):
@@ -191,7 +191,7 @@ class SalesforceToS3Operator(BaseOperator):
         with NamedTemporaryFile("w") as tmp:
 
             # Load the SalesforceHook
-            hook = SalesforceHook(conn_id=self.sf_conn_id, output=tmp.name)
+            hook = SalesforceHook(conn_id=self.sf_conn_id)
 
             # Attempt to login to Salesforce
             # If this process fails, it will raise an error and die.

--- a/operators/salesforce_to_s3_operator.py
+++ b/operators/salesforce_to_s3_operator.py
@@ -257,8 +257,6 @@ class SalesforceToS3Operator(BaseOperator):
                 replace=True
             )
 
-            dest_s3.connection.close()
-
             tmp.close()
 
         logging.info("Query finished!")


### PR DESCRIPTION
This feature adds time selection for salesforce query.
The parameters from_date and to_date gives the possibility to users to make smaller queries within their dags and distribute processing in batches to avoid huge queries.
It also fixes small bugs:
-  in case of empty records query  
- delete s3 connection close 
- make plugin compatible with airflow V2 